### PR TITLE
projectUrl & iconUrl outdated

### DIFF
--- a/automatic/teamspeak/teamspeak.nuspec
+++ b/automatic/teamspeak/teamspeak.nuspec
@@ -8,7 +8,7 @@
     <owners>caskater4</owners>
     <summary>TeamSpeak Client</summary>
     <description>A Voice-Over-IP (VoIP) software developed primarily for gamers to communicate with one another.</description>
-    <projectUrl>http://www.teamspeak.com/?page=teamspeak3</projectUrl>
+    <projectUrl>https://www.teamspeak.com/en/</projectUrl>
     <tags>admin teamspeak team speak ts3 ts voip mumble ventrilo</tags>
     <copyright></copyright>
     <licenseUrl>http://www.teamspeak.com/?page=eula</licenseUrl>


### PR DESCRIPTION
I've fixed the projectUrl for you.
In my fork of your repo you can download the teamspeak.png which is also missing at the moment.
https://github.com/sippi90/chocolatey-packages-1/blob/master/icons/teamspeak.png